### PR TITLE
fix: Set timeout values for HTTP requsts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ $ staticsrv -h
 #     	network interface to expose for serving prometheus metrics (default "0.0.0.0:9090")
 #   -metrics-path string
 #     	http path where prometheus metrics are exported (default "/metrics")
+#   -timeout-idle int
+#       the maximum amount of time to wait for the next request (default 60)
+#   -timeout-read int
+#       the maximum duration for reading the entire request (default 5)
+#   -timeout-write int
+#       the maximum duration before timing out writes of the response (default 5)
 #   -version
 #     	print the current version number of staticsrv
 ```


### PR DESCRIPTION
## Description
Set default timeout values for HTTP requsts.
Add even options to be able to set your own values for main server, while the metric server has fixed values.
See https://pkg.go.dev/net/http#Server

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Run the following commands:
`docker build -t staticsrv:server_with_timeout -f docker/build.dockerfile .`
`docker run -p 8080:8080 -p 9090:9090 -it staticsrv:server_with_timeout` 
### within the container
`staticsrv -enable-metrics` 
or
`staticsrv -enable-metrics -readTimeout 10`
### outside the container
`curl -k http://localhost:8080/livez` # Test basic function
### Run those two commands at the same time in different terminals
`nc -v localhost 8080` 
`watch 'ss -tnp | grep -E "(8080|9090)"'` 

Observed that the created session became from ESTAB to FIN-WAIT-2 (and CLOST-WAIT) according to the timeout value.

* Host OS version: Ubuntu 22.0.4 LTS

## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)